### PR TITLE
Update mpy/mpy.c to MPI > 1

### DIFF
--- a/mpy/mpy.c
+++ b/mpy/mpy.c
@@ -12,6 +12,12 @@
 #define MPY_MPI_H 1
 #include "mpy.h"
 
+#if defined(MPI_VERSION) && MPI_VERSION > 1
+# define MPY_Comm_set_errhandler MPI_Comm_set_errhandler
+#else
+# define MPY_Comm_set_errhandler MPI_Errhandler_set
+#endif /* defined(MPI_VERSION) && MPI_VERSION > 1 */
+
 #include "yapi.h"
 #include "pstdlib.h"
 #include <string.h>
@@ -166,7 +172,7 @@ mpy_initialize(int *pargc, char **pargv[])
         || mpy_size < 2
         || MPI_Comm_dup(MPI_COMM_WORLD, &mpy_world) != MPI_SUCCESS
         || MPI_Comm_rank(mpy_world, &mpy_rank) != MPI_SUCCESS
-        || MPI_Errhandler_set(mpy_world, MPI_ERRORS_RETURN) != MPI_SUCCESS) {
+        || MPY_Comm_set_errhandler(mpy_world, MPI_ERRORS_RETURN) != MPI_SUCCESS) {
       if (mpy_initdone) MPI_Finalize(); /* may be a mistake - no return? */
       mpy_world = MPI_COMM_NULL;
       mpy_size = mpy_rank = 0;


### PR DESCRIPTION
Hi,

mpy is starting to fail building because it still uses MPI_Errhandler_set which is deprecated since MPI2, and "removed" since MPI3 (by default). At least the Debian OpenMPI package starts to ship with the legacy compatibility wrappers disabled.

MPI_Errhandler_set is replaced by MPI_Comm_set_errhandler.

Is this pull request, I use MPI_VERSION to determine whether MPI is above 2, and in this case use the newer interface. I keep the older interface for MPI 1, in case there are still (ageing) clusters using it.

The code thus modified compiles and runs fine with both mpich 3.3 and openmpi 4.0.2.

Kind regards.