### PR TITLE
system call returns the result of the system call

### DIFF
--- a/yorick/ops.c
+++ b/yorick/ops.c
@@ -580,9 +580,11 @@ void CallShell(void)
 void Y_system(int nArgs)
 {
   char *line;
+  int  retval;
   if (nArgs!=1) YError("system function takes exactly one argument");
   line= YGetString(sp);
-  if (line && line[0]) p_system(line);
+  if (line && line[0]) retval = p_system(line);
+  PushIntValue(retval);
 }
 
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
This allows to detect errors when doing system calls and to chain them. To be used as :

retval = system("call to OS system call") 
if retval != 0 ...

has been tested in Linux