### PR TITLE
Some fixes for FITS files

### DIFF
--- a/i/fits.i
+++ b/i/fits.i
@@ -670,7 +670,7 @@ func fits_open(filename, filemode, overwrite=)
 
    SEE ALSO: fits, fits_read_header, fits_write_header,
              fits_get, fits_set, fits_read_array, fits_write_array,
-             fits_next_hdu, fits_new_hdu, fits_rewind, __sun. */
+             fits_next_hdu, fits_new_hdu, fits_rewind, fits_set_primitives. */
 {
   /* Open stream. */
   if (is_void(filemode) || filemode == 'r' || filemode == "r") {
@@ -691,7 +691,7 @@ func fits_open(filename, filemode, overwrite=)
   }
 
   /* Set data primitives. */
-  _fits_set_primitives, stream;
+  fits_set_primitives, stream;
 
   /* Create handle. */
   fh = _lst([], [], [1, 0, 0, 0, filemode], stream);
@@ -4413,14 +4413,15 @@ func fits_get_list(fh, key)
 /*---------------------------------------------------------------------------*/
 /* READING/WRITING OF BINARY DATA */
 
-local _FITS_XDR64, _FITS_INTEL32, _FITS_INTEL64;
-func _fits_set_primitives(stream)
-/* DOCUMENT _fits_set_primitives, stream;
+local _FITS_XDR64;
+func fits_set_primitives(stream)
+/* DOCUMENT fits_set_primitives, stream;
+
      Set binary format of data stream to XDR (eXternal Data Representation)
      which is the same as IEEE format with 32-bits (int) and 64-bits (long)
      integers and big-endian byte order.
-   SEE ALSO: open, set_primitives, fits_open, _fits_vopen, fits_bitpix_type,
-     fits_bitpix_of.
+
+   SEE ALSO: open, set_primitives, fits_open, fits_bitpix_type, fits_bitpix_of.
  */
 {
   set_primitives, stream, _FITS_XDR64;
@@ -4494,11 +4495,11 @@ _fits_false = 'F';
 func fits_init(sloopy=, allow=, blank=)
 /* DOCUMENT fits_init;
 
-     (Re)initializes FITS private data.  Normally you do not have to call this
-     routine  because this routine  is automatically  called when  "fits.i" is
-     parsed by Yorick.  You may  however need to explicitely call fits_init if
-     you suspect that  some FITS private data get corrupted or  if you want to
-     tune FITS strict/sloopy behaviour.
+     (Re)initializes FITS private data. Normally you  do not have to call this
+     routine because  it is  automatically called when  "fits.i" is  parsed by
+     Yorick. You may however need to explicitely call fits_init if you suspect
+     that some  FITS private data  get corrupted or if  you want to  tune FITS
+     strict/sloopy behaviour.
 
      If  keyword SLOOPY  is true  (non-nil and  non-zero) some  discrepancy is
      allowed (for reading FITS file only); otherwise strict FITS compliance is

--- a/i/fits.i
+++ b/i/fits.i
@@ -2227,6 +2227,9 @@ func fits_new_image(fh, data, bitpix=, dimlist=, bzero=, bscale=)
      used to guess the bits per  pixel and the dimension list if not specified
      by the keywords BITPIX and DIMSLIST respectively.
 
+     Keywords PCOUNT=0 and GCOUNT=1 are automatically set right after the
+     last NAXISn keyword.
+
    SEE ALSO: fits, fits_write_array. */
 {
   fits_new_hdu, fh, "IMAGE", "this HDU contains FITS image extension";
@@ -2236,6 +2239,8 @@ func fits_new_image(fh, data, bitpix=, dimlist=, bzero=, bscale=)
   }
   fits_set, fh, "BITPIX", bitpix, fits_bitpix_info(bitpix);
   fits_set_dims, fh, dimlist;
+  fits_set, fh, "PCOUNT", 0, "always 0 for image extensions";
+  fits_set, fh, "GCOUNT", 1, "always 1 for image extensions";
   if (! is_void(bzero)) fits_set, fh, "BZERO", bzero,
                           "data_value = BZERO + BSCALE*file_value";
   if (! is_void(bscale)) fits_set, fh, "BSCALE", bscale,

--- a/i/fits.i
+++ b/i/fits.i
@@ -5,7 +5,7 @@
  *
  *-----------------------------------------------------------------------------
  *
- * Copyright (C) 2000-2015, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>
+ * Copyright (c) 2000-2024, Ã‰ric ThiÃ©baut <eric.thiebaut@univ-lyon1.fr>
  *
  * This file is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License version 2 as published by the
@@ -61,7 +61,7 @@
  *    if not).
  *
  * Revision 1.25  2006/11/03 12:09:18  eric
- *  - Fixed bug in fits_pack_bintable (thanks to Ariane Lançon for discovering
+ *  - Fixed bug in fits_pack_bintable (thanks to Ariane LanÃ§on for discovering
  *    this bug).
  *  - Slightly change the calling sequence of fits_pack_bintable (no side
  *    effects w.r.t. previous version).
@@ -71,7 +71,7 @@
  *    to Christophe Pichon for discovering this bug).
  *
  * Revision 1.23  2006/09/07 07:20:31  eric
- *  - Fixed documentation (thanks to Ariane Lançon).
+ *  - Fixed documentation (thanks to Ariane LanÃ§on).
  *
  * Revision 1.22  2006/09/02 12:39:04  eric
  *  - Minor changes to make the code portable with different versions of
@@ -97,14 +97,14 @@
  *
  * Revision 1.17  2004/10/22 15:19:29  eric
  *  - fits_write_bintable takes into account existing "TFORM#" FITS cards to
- *    format the columns (thanks to Clémentine Béchet).
+ *    format the columns (thanks to ClÃ©mentine BÃ©chet).
  *  - New function: fits_strcmp.
  *
  * Revision 1.16  2004/09/03 09:13:27  eric
  *  - New function fits_pad_hdu to round up file size to a multiple
  *    of FITS blocking factor.
  *  - fits_new_hdu: fix offset of data part by calling fits_pad_hdu
- *    (thanks to Antoine Mérand for pointing this bug).
+ *    (thanks to Antoine MÃ©rand for pointing this bug).
  *  - fits_close: call fits_pad_hdu to finalize stream open for
  *    writing.
  *  - fits_new_image: bitpix and dimension list can be guessed from
@@ -136,11 +136,11 @@
  *
  * Revision 1.12  2004/07/09 09:30:37  eric
  *  - Fixed bug in fits_move and typo in error message for fits_create (thanks
- *    to Clémentine Béchet).
+ *    to ClÃ©mentine BÃ©chet).
  *
  * Revision 1.11  2004/06/22 16:22:49  eric
  *  - Fix a bug in fits_write_bintable which prevents writing strings in a
- *    binary table (thanks to Clémentine Béchet).
+ *    binary table (thanks to ClÃ©mentine BÃ©chet).
  *
  * Revision 1.10  2004/03/19 18:28:45  eric
  *  - New functions: fits_current_hdu, fits_info, fits_eof, fits_list.
@@ -4800,6 +4800,6 @@ fitsOldHeaderKeywords = fits_toupper(fitsOldHeaderMembers);
  * tab-width: 8
  * fill-column: 78
  * c-basic-offset: 2
- * coding: latin-1
+ * coding: utf-8
  * End:
  */


### PR DESCRIPTION
This patch add a few fixes for dealing with FITS files:

- Define PCOUNT and GCOUNT in FITS IMAGE extensions.
- Can read/write 64-bit integers in FITS tables.
- Enforce that `int` and `long` represent `int32` and `int64` in FITS files.